### PR TITLE
README: rename trailofbits/... -> sigstore/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 gh-action-sigstore-python
 =========================
 
-[![CI](https://github.com/trailofbits/gh-action-sigstore-python/actions/workflows/ci.yml/badge.svg)](https://github.com/trailofbits/gh-action-sigstore-python/actions/workflows/ci.yml)
-[![Self-test](https://github.com/trailofbits/gh-action-sigstore-python/actions/workflows/selftest.yml/badge.svg)](https://github.com/trailofbits/gh-action-sigstore-python/actions/workflows/selftest.yml)
+[![CI](https://github.com/sigstore/gh-action-sigstore-python/actions/workflows/ci.yml/badge.svg)](https://github.com/sigstore/gh-action-sigstore-python/actions/workflows/ci.yml)
+[![Self-test](https://github.com/sigstore/gh-action-sigstore-python/actions/workflows/selftest.yml/badge.svg)](https://github.com/sigstore/gh-action-sigstore-python/actions/workflows/selftest.yml)
 
 A GitHub Action that uses [`sigstore-python`](https://github.com/sigstore/sigstore-python)
 to sign Python packages.
@@ -17,7 +17,7 @@ to sign Python packages.
 
 ## Usage
 
-Simply add `trailofbits/gh-action-sigstore-python` to one of your workflows:
+Simply add `sigstore/gh-action-sigstore-python` to one of your workflows:
 
 ```yaml
 jobs:
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install
         run: python -m pip install .
-      - uses: trailofbits/gh-action-sigstore-python@v0.0.9
+      - uses: sigstore/gh-action-sigstore-python@v0.0.9
         with:
           inputs: file.txt
 ```
@@ -55,7 +55,7 @@ provided.
 To sign one or more files:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file0.txt file1.txt file2.txt
 ```
@@ -63,7 +63,7 @@ To sign one or more files:
 The `inputs` argument also supports file globbing:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: ./path/to/inputs/*.txt
 ```
@@ -76,7 +76,7 @@ The `identity-token` setting controls the OpenID Connect token provided to Fulci
 workflow will use the credentials found in the GitHub Actions environment.
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     identity-token: ${{ IDENTITY_TOKEN  }} # assigned elsewhere
@@ -92,7 +92,7 @@ Server during OAuth2.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     oidc-client-id: alternative-sigstore-id
@@ -108,7 +108,7 @@ Connect Server during OAuth2.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     oidc-client-secret: alternative-sigstore-secret
@@ -124,7 +124,7 @@ when signing multiple input files.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     signature: custom-signature-filename.sig
@@ -133,7 +133,7 @@ Example:
 However, this example is invalid:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file0.txt file1.txt file2.txt
     signature: custom-signature-filename.sig
@@ -149,7 +149,7 @@ work when signing multiple input files.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     certificate: custom-certificate-filename.crt
@@ -158,7 +158,7 @@ Example:
 However, this example is invalid:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file0.txt file1.txt file2.txt
     certificate: custom-certificate-filename.crt
@@ -174,7 +174,7 @@ from. This setting cannot be used in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     fulcio-url: https://fulcio.sigstage.dev
@@ -190,7 +190,7 @@ cannot be used in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     rekor-url: https://rekor.sigstage.dev
@@ -206,7 +206,7 @@ in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     ctfe: ./path/to/ctfe.pub
@@ -222,7 +222,7 @@ be used in combination with `staging` setting.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     ctfe: ./path/to/rekor.pub
@@ -238,7 +238,7 @@ instead of the default production instances.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     staging: true
@@ -258,7 +258,7 @@ generated properly and the signature was properly submitted to Rekor.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     verify: false
@@ -275,7 +275,7 @@ certificate's SAN against the provided value.
 This setting only applies if `verify` is set to `true`.
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     verify-cert-email: john.smith@example.com
@@ -294,7 +294,7 @@ This setting only applies if `verify` is set to `true`.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     verify-oidc-issuer: https://oauth2.sigstage.dev/auth
@@ -314,7 +314,7 @@ workflow artifact retention period is used.
 Example:
 
 ```yaml
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     upload-signing-artifacts: true
@@ -339,7 +339,7 @@ permissions:
 
 # ...
 
-- uses: trailofbits/gh-action-sigstore-python@v0.0.9
+- uses: sigstore/gh-action-sigstore-python@v0.0.9
   with:
     inputs: file.txt
     release-signing-artifacts: true
@@ -366,7 +366,7 @@ permissions:
   Example:
 
   ```yaml
-  - uses: trailofbits/gh-action-sigstore-python@v0.0.9
+  - uses: sigstore/gh-action-sigstore-python@v0.0.9
     with:
       inputs: file.txt
       internal-be-careful-debug: true


### PR DESCRIPTION
Now that we've migrated to the Sigstore org, these references need to be updated.

Signed-off-by: William Woodruff <william@trailofbits.com>
