### PR TITLE
chore: fix deprecated set-output

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -106,7 +106,7 @@ jobs:
               "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" \
             | jq -r .value \
           )
-          echo "::set-output name=identity-token::$identity_token"
+          echo "identity-token=$identity_token" >> $GITHUB_OUTPUT
         shell: bash
       - name: Sign artifact and publish signature
         uses: ./


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Bob Callaway <bcallaway@google.com>