### PR TITLE
Prep 1.0.0

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -182,3 +182,25 @@ jobs:
           inputs: ./test/artifact.txt
           identity-token: ${{ steps.get-oidc-token.outputs.identity-token }}
           staging: true
+
+  all-selftests-pass:
+    if: always()
+
+    needs:
+    - selftest
+    - selftest-xfail-invalid-inputs
+    - selftest-staging
+    - selftest-glob
+    - selftest-upload-artifacts
+    - selftest-custom-paths
+    - selftest-verify
+    - selftest-xfail-verify-missing-options
+    - selftest-identity-token
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check test jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install
         run: python -m pip install .
-      - uses: sigstore/gh-action-sigstore-python@v0.3.0
+      - uses: sigstore/gh-action-sigstore-python@v1.0.0
         with:
           inputs: file.txt
 ```
@@ -53,7 +53,7 @@ provided.
 To sign one or more files:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file0.txt file1.txt file2.txt
 ```
@@ -61,7 +61,7 @@ To sign one or more files:
 The `inputs` argument also supports file globbing:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: ./path/to/inputs/*.txt
 ```
@@ -74,7 +74,7 @@ The `identity-token` setting controls the OpenID Connect token provided to Fulci
 workflow will use the credentials found in the GitHub Actions environment.
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     identity-token: ${{ IDENTITY_TOKEN  }} # assigned elsewhere
@@ -90,7 +90,7 @@ Server during OAuth2.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     oidc-client-id: alternative-sigstore-id
@@ -106,7 +106,7 @@ Connect Server during OAuth2.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     oidc-client-secret: alternative-sigstore-secret
@@ -122,7 +122,7 @@ when signing multiple input files.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     signature: custom-signature-filename.sig
@@ -131,7 +131,7 @@ Example:
 However, this example is invalid:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file0.txt file1.txt file2.txt
     signature: custom-signature-filename.sig
@@ -147,7 +147,7 @@ work when signing multiple input files.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     certificate: custom-certificate-filename.crt
@@ -156,7 +156,7 @@ Example:
 However, this example is invalid:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file0.txt file1.txt file2.txt
     certificate: custom-certificate-filename.crt
@@ -172,7 +172,7 @@ from. This setting cannot be used in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     fulcio-url: https://fulcio.sigstage.dev
@@ -188,7 +188,7 @@ cannot be used in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     rekor-url: https://rekor.sigstage.dev
@@ -204,7 +204,7 @@ in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     ctfe: ./path/to/ctfe.pub
@@ -220,7 +220,7 @@ be used in combination with `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     ctfe: ./path/to/rekor.pub
@@ -236,7 +236,7 @@ instead of the default production instances.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     staging: true
@@ -259,7 +259,7 @@ and `verify-oidc-issuer` settings. Failing to pass these will produce an error.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     verify: true
@@ -282,7 +282,7 @@ This setting may only be used in conjunction with `verify-oidc-issuer`.
 Supplying it without `verify-oidc-issuer` will produce an error.
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     verify: true
@@ -307,7 +307,7 @@ Supplying it without `verify-cert-identity` will produce an error.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     verify: true
@@ -329,7 +329,7 @@ workflow artifact retention period is used.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     upload-signing-artifacts: true
@@ -354,7 +354,7 @@ permissions:
 
 # ...
 
-- uses: sigstore/gh-action-sigstore-python@v0.3.0
+- uses: sigstore/gh-action-sigstore-python@v1.0.0
   with:
     inputs: file.txt
     release-signing-artifacts: true
@@ -381,7 +381,7 @@ permissions:
   Example:
 
   ```yaml
-  - uses: sigstore/gh-action-sigstore-python@v0.3.0
+  - uses: sigstore/gh-action-sigstore-python@v1.0.0
     with:
       inputs: file.txt
       internal-be-careful-debug: true

--- a/action.py
+++ b/action.py
@@ -176,9 +176,9 @@ for input_ in inputs:
     for file_ in files:
         if not file_.is_file():
             _fatal_help(f"input {file_} does not look like a file")
-        if "--output_certificate" not in sigstore_sign_args:
+        if "--certificate" not in sigstore_sign_args:
             signing_artifact_paths.append(f"{file_}.crt")
-        if "--output_signature" not in sigstore_sign_args:
+        if "--signature" not in sigstore_sign_args:
             signing_artifact_paths.append(f"{file_}.sig")
 
     sigstore_sign_args.extend(files)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sigstore==0.10.0
+sigstore ~= 1.0


### PR DESCRIPTION
Now that we have a stable release of `sigstore-python`, we should also do a stable release here,