### PR TITLE
action: download default release assets to sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ Example:
 The `release-signing-artifacts` setting controls whether or not `sigstore-python`
 uploads signing artifacts to the release publishing event that triggered this run.
 
+If enabled, this setting also re-uploads and signs GitHub's default source code artifacts,
+as they are not guaranteed to be stable.
+
 By default, no release assets are uploaded.
 
 Requires the [`contents: write` permission](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

--- a/action.py
+++ b/action.py
@@ -59,16 +59,16 @@ def _download_ref_asset(ext):
     repo = os.getenv('GITHUB_REPOSITORY')
     ref = os.getenv("GITHUB_REF")
 
-    artifact = f"/tmp/{os.getenv('GITHUB_REF_NAME')}{ext}"
+    artifact = Path(f"/tmp/{os.getenv('GITHUB_REF_NAME')}").with_suffix(ext)
 
     # GitHub supports /:org/:repo/archive/:ref<.tar.gz|.zip>.
     r = requests.get(f"https://github.com/{repo}/archive/{ref}{ext}", stream=True)
     r.raise_for_status()
-    with Path(artifact).open("wb") as io:
+    with artifact.open("wb") as io:
         for chunk in r.iter_content(chunk_size=None):
             io.write(chunk)
 
-    return artifact
+    return str(artifact)
 
 
 def _sigstore_sign(global_args, sign_args):

--- a/action.yml
+++ b/action.yml
@@ -123,6 +123,7 @@ runs:
         GHA_SIGSTORE_PYTHON_VERIFY: "${{ inputs.verify }}"
         GHA_SIGSTORE_PYTHON_VERIFY_CERT_IDENTITY: "${{ inputs.verify-cert-identity }}"
         GHA_SIGSTORE_PYTHON_VERIFY_OIDC_ISSUER: "${{ inputs.verify-oidc-issuer }}"
+        GHA_SIGSTORE_PYTHON_RELEASE_SIGNING_ARTIFACTS: "${{ inputs.release-signing-artifacts }}"
         GHA_SIGSTORE_PYTHON_INTERNAL_BE_CAREFUL_DEBUG: "${{ inputs.internal-be-careful-debug }}"
       shell: bash
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sigstore ~= 1.1
+requests ~= 2.28


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR resolves #44. We now do the following on releases if `release-signing-artifacts` is enabled:

1. Download the default release artifacts, i.e.`{{ref}}.tar.gz` and `{{ref}}.zip`;
2. Sign for them;
3. Upload them back to the release as `{{ref}}-signed.{{extension}}`, along with their signatures.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

The `release-signing-artifacts` setting was extended to re-upload and sign default assets. Previously, the stability of default asset hashes were not guaranteed, as they are generated on-the-fly by GitHub.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
https://docs.sigstore.dev does not seem to include documentation on the actions, but I will add a commit documenting the change to `release-signing-artifacts` in this repo's README.