### PR TITLE
Bugfix, prep 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install
         run: python -m pip install .
-      - uses: sigstore/gh-action-sigstore-python@v1.2.0
+      - uses: sigstore/gh-action-sigstore-python@v1.2.1
         with:
           inputs: file.txt
 ```
@@ -53,7 +53,7 @@ provided.
 To sign one or more files:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file0.txt file1.txt file2.txt
 ```
@@ -61,7 +61,7 @@ To sign one or more files:
 The `inputs` argument also supports file globbing:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: ./path/to/inputs/*.txt
 ```
@@ -74,7 +74,7 @@ The `identity-token` setting controls the OpenID Connect token provided to Fulci
 workflow will use the credentials found in the GitHub Actions environment.
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     identity-token: ${{ IDENTITY_TOKEN  }} # assigned elsewhere
@@ -90,7 +90,7 @@ Server during OAuth2.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     oidc-client-id: alternative-sigstore-id
@@ -106,7 +106,7 @@ Connect Server during OAuth2.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     oidc-client-secret: alternative-sigstore-secret
@@ -122,7 +122,7 @@ when signing multiple input files.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     signature: custom-signature-filename.sig
@@ -131,7 +131,7 @@ Example:
 However, this example is invalid:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file0.txt file1.txt file2.txt
     signature: custom-signature-filename.sig
@@ -147,7 +147,7 @@ work when signing multiple input files.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     certificate: custom-certificate-filename.crt
@@ -156,7 +156,7 @@ Example:
 However, this example is invalid:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file0.txt file1.txt file2.txt
     certificate: custom-certificate-filename.crt
@@ -172,7 +172,7 @@ when signing multiple input files.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     bundle: custom-bundle.sigstore
@@ -181,7 +181,7 @@ Example:
 However, this example is invalid:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file0.txt file1.txt file2.txt
     certificate: custom-bundle.sigstore
@@ -197,7 +197,7 @@ from. This setting cannot be used in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     fulcio-url: https://fulcio.sigstage.dev
@@ -213,7 +213,7 @@ cannot be used in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     rekor-url: https://rekor.sigstage.dev
@@ -229,7 +229,7 @@ in combination with the `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     ctfe: ./path/to/ctfe.pub
@@ -245,7 +245,7 @@ be used in combination with `staging` setting.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     ctfe: ./path/to/rekor.pub
@@ -261,7 +261,7 @@ instead of the default production instances.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     staging: true
@@ -284,7 +284,7 @@ and `verify-oidc-issuer` settings. Failing to pass these will produce an error.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     verify: true
@@ -307,7 +307,7 @@ This setting may only be used in conjunction with `verify-oidc-issuer`.
 Supplying it without `verify-oidc-issuer` will produce an error.
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     verify: true
@@ -332,7 +332,7 @@ Supplying it without `verify-cert-identity` will produce an error.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     verify: true
@@ -354,7 +354,7 @@ workflow artifact retention period is used.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     upload-signing-artifacts: true
@@ -382,7 +382,7 @@ permissions:
 
 # ...
 
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     release-signing-artifacts: true
@@ -404,7 +404,7 @@ signing artifact is uploaded.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v1.2.0
+- uses: sigstore/gh-action-sigstore-python@v1.2.1
   with:
     inputs: file.txt
     upload-signing-artifacts: true
@@ -432,7 +432,7 @@ Example:
   Example:
 
   ```yaml
-  - uses: sigstore/gh-action-sigstore-python@v1.2.0
+  - uses: sigstore/gh-action-sigstore-python@v1.2.1
     with:
       inputs: file.txt
       internal-be-careful-debug: true

--- a/action.py
+++ b/action.py
@@ -59,10 +59,10 @@ def _download_ref_asset(ext):
     repo = os.getenv("GITHUB_REPOSITORY")
     ref = os.getenv("GITHUB_REF")
 
-    artifact = Path(f"/tmp/{os.getenv('GITHUB_REF_NAME')}").with_suffix(ext)
+    artifact = Path(f"/tmp/{os.getenv('GITHUB_REF_NAME')}.{ext}")
 
     # GitHub supports /:org/:repo/archive/:ref<.tar.gz|.zip>.
-    r = requests.get(f"https://github.com/{repo}/archive/{ref}{ext}", stream=True)
+    r = requests.get(f"https://github.com/{repo}/archive/{ref}.{ext}", stream=True)
     r.raise_for_status()
     with artifact.open("wb") as io:
         for chunk in r.iter_content(chunk_size=None):
@@ -182,7 +182,7 @@ else:
     sigstore_verify_args.extend(["--cert-oidc-issuer", verify_oidc_issuer])
 
 if os.getenv("GHA_SIGSTORE_PYTHON_RELEASE_SIGNING_ARTIFACTS") == "true":
-    for filetype in [".zip", ".tar.gz"]:
+    for filetype in ["zip", "tar.gz"]:
         artifact = _download_ref_asset(filetype)
         if artifact is not None:
             signing_artifact_paths.append(artifact)


### PR DESCRIPTION
Fixes the handling of suffixes; the previous use of `with_suffix` would mangle the artifact names if they contained anything that looked like a suffix (e.g. a minor version).