### PR TITLE
action: upload artifact being signed for

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -95,6 +95,17 @@ jobs:
           inputs: ./test/artifact.txt
           staging: true
           upload-signing-artifacts: true
+      - uses: actions/download-artifact@v3
+        with:
+          name: "signing-artifacts-${{ github.job }}"
+          path: ./test/uploaded
+      - name: Verify presence of uploaded files
+        run: |
+          [[ -f ./artifact.txt ]] || exit 1
+          [[ -f ./artifact.txt.sig ]] || exit 1
+          [[ -f ./artifact.txt.crt ]] || exit 1
+          [[ -f ./artifact.txt.sigstore ]] || exit 1
+        working-directory: ./test/uploaded
 
   selftest-custom-paths:
     runs-on: ubuntu-latest

--- a/action.py
+++ b/action.py
@@ -200,6 +200,10 @@ for input_ in inputs:
     for file_ in files:
         if not file_.is_file():
             _fatal_help(f"input {file_} does not look like a file")
+
+        # Also upload artifact being signed for.
+        signing_artifact_paths.append(file_)
+
         if not bundle_only and "--certificate" not in sigstore_sign_args:
             signing_artifact_paths.append(f"{file_}.crt")
         if not bundle_only and "--signature" not in sigstore_sign_args:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Resolves #54.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

The action now uploads the original artifacts from `inputs` alongside their signatures.