### PR TITLE
requirements: sigstore ~= 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sigstore == 2.0.0rc3
+sigstore ~= 2.0
 requests ~= 2.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sigstore ~= 2.0
+sigstore == 2.0.0rc3
 requests ~= 2.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sigstore ~= 1.1.2
+sigstore ~= 2.0
 requests ~= 2.28


### PR DESCRIPTION
Bumps our use of sigstore-python to 2.0.

~~We only have prereleases out at the moment, so this should resolve to the latest one (until we make a stable release).~~