### PR TITLE
requirements: bump sigstore-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-sigstore ~= 2.0
+sigstore ~= 2.1
 requests ~= 2.28
-# TODO: Remove with the next sigstore-python release.
-sigstore-rekor-types == 0.0.11

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -46,3 +46,5 @@ min_vers=$(cut -d '.' -f2 <<< "${vers}")
 [[ "${maj_vers}" == "3" && "${min_vers}" -ge 7 ]] || die "Bad Python version: ${vers}"
 
 python -m pip install --requirement "${GITHUB_ACTION_PATH}/requirements.txt"
+
+python -m sigstore --version

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -47,4 +47,4 @@ min_vers=$(cut -d '.' -f2 <<< "${vers}")
 
 python -m pip install --requirement "${GITHUB_ACTION_PATH}/requirements.txt"
 
-python -m sigstore --version
+debug "sigstore-python: $(python -m sigstore --version)"


### PR DESCRIPTION
Seals off the resolution bug we saw in #94.

I'll do a release after this.