### PR TITLE
Fix `release-signing-artifacts` behavior and docs

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -38,6 +38,35 @@ jobs:
         run: |
           [[ -f ./test/artifact.txt.sigstore ]] || exit 1
 
+  selftest-release-signing-artifacts-no-op:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    if: (github.event_name != 'pull_request') || !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        with:
+          python-version: "3.x"
+      - name: Sign artifact and publish signature
+        uses: ./
+        id: sigstore-python
+        with:
+          inputs: ./test/artifact.txt
+          # The trigger for this test is not a release, so this has no effect
+          # (but does not break the workflow either).
+          release-signing-artifacts: true
+          internal-be-careful-debug: true
+      - name: Check outputs
+        shell: bash
+        run: |
+          [[ -f ./test/artifact.txt.sigstore ]] || exit 1
+
   selftest-xfail-invalid-inputs:
     runs-on: ubuntu-latest
     strategy:
@@ -285,6 +314,7 @@ jobs:
 
     needs:
       - selftest
+      - selftest-release-signing-artifacts-no-op
       - selftest-xfail-invalid-inputs
       - selftest-staging
       - selftest-glob

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Example:
 
 The `release-signing-artifacts` setting controls whether or not `sigstore-python`
 uploads signing artifacts to the release publishing event that triggered this run.
+This setting has no effect on non-`release` events.
 
 If enabled, this setting also re-uploads and signs GitHub's default source code artifacts,
 as they are not guaranteed to be stable.

--- a/action.py
+++ b/action.py
@@ -38,6 +38,11 @@ _SUMMARY = Path(_summary_path).open("a")
 _RENDER_SUMMARY = os.getenv("GHA_SIGSTORE_PYTHON_SUMMARY", "true") == "true"
 _DEBUG = os.getenv("GHA_SIGSTORE_PYTHON_INTERNAL_BE_CAREFUL_DEBUG", "false") != "false"
 
+_RELEASE_SIGNING_ARTIFACTS = (
+    os.getenv("GHA_SIGSTORE_PYTHON_RELEASE_SIGNING_ARTIFACTS", "true") == "true"
+    and os.getenv("GITHUB_EVENT_NAME") == "release"
+)
+
 
 def _template(name):
     path = _TEMPLATES / f"{name}.md"
@@ -189,7 +194,7 @@ elif not enable_verify and verify_oidc_issuer:
 elif verify_oidc_issuer:
     sigstore_verify_args.extend(["--cert-oidc-issuer", verify_oidc_issuer])
 
-if os.getenv("GHA_SIGSTORE_PYTHON_RELEASE_SIGNING_ARTIFACTS") == "true":
+if _RELEASE_SIGNING_ARTIFACTS:
     for filetype in ["zip", "tar.gz"]:
         artifact = _download_ref_asset(filetype)
         if artifact is not None:


### PR DESCRIPTION
This has two parts:

* We now silently ignore `release-signing-artifacts` if the `GITHUB_EVENT_NAME` is not `release`, since it can only work in the context of releases and their associated artifacts.
* The documentation for `release-signing-artifacts` now makes this clear.

CC @stevenh for review as well, as the original reporter 🙂 

Closes #99.