### PR TITLE
action: use shlex.split

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -38,6 +38,37 @@ jobs:
         run: |
           [[ -f ./test/artifact.txt.sigstore ]] || exit 1
 
+  selftest-whitespace:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    if: (github.event_name != 'pull_request') || !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        with:
+          python-version: "3.x"
+      - name: Sign artifact and publish signature
+        uses: ./
+        id: sigstore-python
+        with:
+          inputs: |
+            ./test/artifact.txt
+            ./test/white\ space.txt
+            ./test/"more white space.txt"
+          internal-be-careful-debug: true
+      - name: Check outputs
+        shell: bash
+        run: |
+          [[ -f ./test/artifact.txt.sigstore ]] || exit 1
+          [[ -f ./test/white\ space.txt ]] || exit 1
+          [[ -f ./test/more\ white\ space.txt ]] || exit 1
+
   selftest-release-signing-artifacts-no-op:
     strategy:
       matrix:

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -345,6 +345,7 @@ jobs:
 
     needs:
       - selftest
+      - selftest-whitespace
       - selftest-release-signing-artifacts-no-op
       - selftest-xfail-invalid-inputs
       - selftest-staging

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ The `inputs` argument also supports file globbing:
     inputs: ./path/to/inputs/*.txt
 ```
 
+Multiple lines are fine, and whitespace in filenames can also be escaped using
+POSIX shell lexing rules:
+
+```yaml
+- uses: sigstore/gh-action-sigstore-python@v2.1.1
+  with:
+    inputs: |
+      ./path/to/inputs/*.txt
+      ./another/path/foo\ bar.txt
+      ./a/third/path/"easier to quote than to escape".txt
+```
+
 > [!NOTE]\
 > In versions of this action before 2.0.0, the `inputs` setting allowed for shell expansion.
 > This was unintentional, and was removed with 2.0.0.

--- a/action.py
+++ b/action.py
@@ -20,6 +20,7 @@
 # is a whitespace-separated list of inputs
 
 import os
+import shlex
 import string
 import subprocess
 import sys
@@ -100,16 +101,12 @@ def _sigstore_verify(global_args, verify_args):
     ]
 
 
-def _warning(msg):
-    print(f"::warning::⚠️ {msg}")
-
-
 def _fatal_help(msg):
     print(f"::error::❌ {msg}")
     sys.exit(1)
 
 
-inputs = sys.argv[1].split()
+inputs = shlex.split(sys.argv[1])
 
 # The arguments we pass into `sigstore-python` get built up in these lists.
 sigstore_global_args = []

--- a/test/more white space.txt
+++ b/test/more white space.txt
@@ -1,0 +1,1 @@
+This is another input with a whitespace filename.

--- a/test/white space.txt
+++ b/test/white space.txt
@@ -1,0 +1,1 @@
+This input has a filename with whitespace in it.


### PR DESCRIPTION
Makes `inputs` slightly more uniform. Needs self-tests.

Closes #77.
