### PR TITLE
schedule-selftest: reduce nagging

### DIFF
--- a/.github/workflows/schedule-selftest.yml
+++ b/.github/workflows/schedule-selftest.yml
@@ -43,4 +43,4 @@ jobs:
           # created in the previous step
           content-filepath: /tmp/issue.md
           labels: bug
-          assignees: woodruffw,tetsuo-cpp,tnytown
+          assignees: woodruffw


### PR DESCRIPTION
This is a known persistent performance issue with staging; most people don't need to be nagged about it.