### PR TITLE
Enable debugging also if ACTIONS_STEP_DEBUG==true

### DIFF
--- a/action.py
+++ b/action.py
@@ -37,7 +37,8 @@ assert _summary_path is not None
 _SUMMARY = Path(_summary_path).open("a")
 
 _RENDER_SUMMARY = os.getenv("GHA_SIGSTORE_PYTHON_SUMMARY", "true") == "true"
-_DEBUG = os.getenv("GHA_SIGSTORE_PYTHON_INTERNAL_BE_CAREFUL_DEBUG", "false") != "false"
+_DEBUG = os.getenv("GHA_SIGSTORE_PYTHON_INTERNAL_BE_CAREFUL_DEBUG", "false") != "false" or \
+    os.getenv("ACTIONS_STEP_DEBUG", "false") == "true"
 
 _RELEASE_SIGNING_ARTIFACTS = (
     os.getenv("GHA_SIGSTORE_PYTHON_RELEASE_SIGNING_ARTIFACTS", "true") == "true"

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -22,8 +22,10 @@ die() {
 }
 
 debug() {
-  if [[ "${GHA_SIGSTORE_PYTHON_INTERNAL_BE_CAREFUL_DEBUG}" = "true" ]]; then
-    echo -e "\033[93mDEBUG: ${1}\033[0m"
+  if [[ "${GHA_SIGSTORE_PYTHON_INTERNAL_BE_CAREFUL_DEBUG:-false}" != "false" || \
+        "${ACTIONS_STEP_DEBUG:-false}" == 'true' ]]
+  then
+    echo -e "\033[93mDEBUG: ${1}\033[0m" >&2
   fi
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

ACTIONS_STEP_DEBUG is a standard GitHub Actions flag to enable debugging output across all actions and workflows.

See: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging

Supersedes: https://github.com/sigstore/gh-action-sigstore-python/pull/150

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
FIX: debugging output is now enabled also with the standard `ACTIONS_STEP_DEBUG==true` environment variable.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE
