### PR TITLE
README: add a notice about whether this action is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ gh-action-sigstore-python
 A GitHub Action that uses [`sigstore-python`](https://github.com/sigstore/sigstore-python)
 to generate Sigstore signatures.
 
+> [!IMPORTANT]
+>
+> Are you publishing a package? If so, you **do not need this action**:
+> [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)
+> will handle signing for you!
+
 ## Index
 
 * [Usage](#usage)


### PR DESCRIPTION
Adds a notice that'll hopefully divert more people from this action when they don't actually need it (now that PyPI's support for attestations is complete).