### PR TITLE
requirements: Include main.in contents within dev.in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 all:
 	@echo "Run my targets individually!"
 
-.venv/pyvenv.cfg: requirements/dev.txt requirements/main.txt
+.venv/pyvenv.cfg: requirements/dev.txt
 	uv venv
 	. ./.venv/bin/activate && \
-	uv pip install -r requirements/main.txt -r requirements/dev.txt
+	uv pip install -r requirements/dev.txt
 
 .PHONY: dev
 dev: .venv/pyvenv.cfg

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,3 +3,7 @@ isort
 black
 mypy
 types-requests
+
+# copied from main.in
+sigstore ~= 3.6
+requests ~= 2.32


### PR DESCRIPTION
This way we only need to install one requirements/*.txt at any one time so the version numbers in the two cannot clash.

Dependabot does not seem to handle "-r main.in" or "-r main.txt" very well so that was not used here.

--- 

I'll take improve suggestions but based on my quick tests in a fork, dependabot doesn't cope with "requirements files in requirements files" well.

This should let dependabot unbreak #220 