### PR TITLE
dependabot: Use dependency-type: "all"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "all"
     groups:
       python-dependencies:
         patterns:


### PR DESCRIPTION
This should mean we get dependency updates for indirect dependencies as well. There are a couple of caveats:
* I've seen dependabot silently fail when the update is complicated (I believe because the PR grouping doesn't quite work as well as it should with this feature): In any case we can't 100% depend on this
* It's not clear that we _really_ want to update everything as soon as new versions become available.

That said, I think trying to stay up-to-date (or at least getting PRs for everything) and relying on selftest to find issues is still a better strategy than relying on humans remembering to run pip-compile.

Fixes #223 , I think
