### PR TITLE
More strict Python version checks

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -20,9 +20,11 @@ jobs:
         # we may not actively support everything in this matrix but we do
         # want to know if they break
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.x", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.x", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: ubuntu-latest
+            python-version: platform-default
+          - os: macos-latest
             python-version: platform-default
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 3.0.0 are untracked.
 
 ## [Unreleased]
 
+### Changed
+
+* The action now requires Python >= 3.11 (in practice 3.1.0 already failed to install on
+  older versions). Supported Python versions are now tested explicitly.
+  ([#238](https://github.com/sigstore/gh-action-sigstore-python/pull/238))
+
+
 ## [3.1.0]
 
 `gh-action-sigstore-python` is now compatible with [Rekor v2](https://blog.sigstore.dev/rekor-v2-ga/)

--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ jobs:
           inputs: file.txt
 ```
 
-Note: Your workflow **must** have permission to request the OIDC token to authenticate with.
-This can be done by setting `id-token: write` on your job (as above) or workflow.
+The action requires Python >= 3.11: [`actions/setup-python`](https://github.com/actions/setup-python) can be used to select the Python version.
+The GitHub runner provided Python can be used but note that the default Python on GitHub Windows runner is **not** compatible at time of writing.
 
-More information about permission settings can be found
+Note: Your workflow **must** have permission to request the OIDC token to authenticate with.
+This can be done by setting `id-token: write` on your job as above. More information about
+permission settings can be found
 [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings).
 
 ## Configuration

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -37,15 +37,12 @@ if [[ "${0}" == "${BASH_SOURCE[0]}" ]]; then
   die "Internal error: setup harness was executed instead of being sourced?"
 fi
 
-# Check the Python version, making sure it's new enough (3.9+)
-# The installation step immediately below will technically catch this,
-# but doing it explicitly gives us the opportunity to produce a better
-# error message.
+# Check the Python version, making sure it's new enough (3.11+)
 vers=$(python -V | cut -d ' ' -f2)
 maj_vers=$(cut -d '.' -f1 <<< "${vers}")
 min_vers=$(cut -d '.' -f2 <<< "${vers}")
 
-[[ "${maj_vers}" == "3" && "${min_vers}" -ge 9 ]] || die "Bad Python version: ${vers}"
+[[ "${maj_vers}" == "3" && "${min_vers}" -ge 11 ]] || die "Bad Python version: ${vers}"
 
 # If the user didn't explicitly configure a Python version with
 # `actions/setup-python`, then we might be using the distribution's Python and


### PR DESCRIPTION
This "improves" the situation with #235, #236 (essentially making them WONTFIX -- but we may still want to start managing python versions ourselves later):
* Actively fail setup with Python < 3.11: this makes the error message more reasonable
* start testing with python versions 3.11 - 3.14: even if we don't necessarily want to support everything, we do want to know if they work or not

This PR does *not* handle forcing a specific python in the action (by using actions/setup-python or uv): I think that's probably a good direction to go but I went for this simple fix first.

