### PR TITLE
Fix .python-version lookup

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.x", "3.14"]
+        python-version: ["3.x", "3.10", "3.14"]
         include:
           - os: ubuntu-latest
             python-version: platform-default

--- a/setup/create-venv.sh
+++ b/setup/create-venv.sh
@@ -12,6 +12,8 @@ if [ -z "$1" ]; then
 fi
 
 ENV=$1
+SCRIPT_DIR=$(dirname "$0")
+PYTHON_VERSION=$(cat "$SCRIPT_DIR/../.python-version")
 
 BOOTSTRAP_ENV=$(mktemp -d)
 python3 -m venv --clear "$BOOTSTRAP_ENV"
@@ -24,6 +26,10 @@ else
 fi
 
 
-. "$BIN/activate" && pip install uv && uv venv --clear "$ENV" && VIRTUAL_ENV="$ENV" uv pip install uv
+. "$BIN/activate" && \
+  pip install uv && \
+  uv venv --python "$PYTHON_VERSION" --clear "$ENV" && \
+  VIRTUAL_ENV="$ENV" uv pip install uv
+
 touch "$ENV/bootstrap"
 rm -r "$BOOTSTRAP_ENV"


### PR DESCRIPTION
Our selftest and Makefile happily find the .python-version in the working directory, but for actual users of the action it's not as easy: The .python-version is actually in the action path.

I'm re-adding 3.10 to test matrix so we can for sure see the python version selection in the logs