### PR TITLE
Document 3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All versions prior to 3.0.0 are untracked.
 
 ## [Unreleased]
 
+## [3.2.0]
+
+`gh-action-sigstore-python` now manages the used Python version internally, improving reliability.
+
+### Changed
+* Manage Python version internally
+  ([#242](https://github.com/sigstore/gh-action-sigstore-python/pull/242),
+  [#258](https://github.com/sigstore/gh-action-sigstore-python/pull/258))
+* Dependency updates
+
+
 ## [3.1.0]
 
 `gh-action-sigstore-python` is now compatible with [Rekor v2](https://blog.sigstore.dev/rekor-v2-ga/)

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: install
-        run: python -m pip install .
-      - uses: sigstore/gh-action-sigstore-python@v3.1.0
+      - name: Build step
+        run: echo "build result example" > file.txt
+      - uses: sigstore/gh-action-sigstore-python@v3.2.0
         with:
           inputs: file.txt
 ```
@@ -60,7 +60,7 @@ provided unless [release-signing-artifacts](#release-signing-artifacts) is set t
 To sign one or more files:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file0.txt file1.txt file2.txt
 ```
@@ -68,7 +68,7 @@ To sign one or more files:
 The `inputs` argument also supports file globbing:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: ./path/to/inputs/*.txt
 ```
@@ -77,7 +77,7 @@ Multiple lines are fine, and whitespace in filenames can also be escaped using
 POSIX shell lexing rules:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: |
       ./path/to/inputs/*.txt
@@ -97,7 +97,7 @@ The `identity-token` setting controls the OpenID Connect token provided to Fulci
 workflow will use the credentials found in the GitHub Actions environment.
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     identity-token: ${{ IDENTITY_TOKEN  }} # assigned elsewhere
@@ -113,7 +113,7 @@ Server during OAuth2.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     oidc-client-id: alternative-sigstore-id
@@ -129,7 +129,7 @@ Connect Server during OAuth2.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     oidc-client-secret: alternative-sigstore-secret
@@ -145,7 +145,7 @@ instead of the default production instances.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     staging: true
@@ -168,7 +168,7 @@ and `verify-oidc-issuer` settings. Failing to pass these will produce an error.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     verify: true
@@ -191,7 +191,7 @@ This setting may only be used in conjunction with `verify-oidc-issuer`.
 Supplying it without `verify-oidc-issuer` will produce an error.
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     verify: true
@@ -216,7 +216,7 @@ Supplying it without `verify-cert-identity` will produce an error.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     verify: true
@@ -238,7 +238,7 @@ workflow artifact retention period is used.
 Example:
 
 ```yaml
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     upload-signing-artifacts: true
@@ -265,7 +265,7 @@ permissions:
 
 # ...
 
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
   with:
     inputs: file.txt
     release-signing-artifacts: true
@@ -281,7 +281,7 @@ permissions:
 # ...
 
 # no explicit settings needed, signs all pre-existing release artifacts
-- uses: sigstore/gh-action-sigstore-python@v3.1.0
+- uses: sigstore/gh-action-sigstore-python@v3.2.0
 ```
 
 ### Internal options
@@ -305,7 +305,7 @@ permissions:
   Example:
 
   ```yaml
-  - uses: sigstore/gh-action-sigstore-python@v3.1.0
+  - uses: sigstore/gh-action-sigstore-python@v3.2.0
     with:
       inputs: file.txt
       internal-be-careful-debug: true


### PR DESCRIPTION
* Update CHANGELOG
* Update version used in README
* Tweak README Usage example to remove the unnecessary pip install and to make it more clear that signed artifact is typically produced in the workflow